### PR TITLE
1.9.4-1.19.3 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,213 +1,29 @@
-name: Publish Release
+name: Build
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release"
-        required: true
-      after-version:
-        description: "Snapshot version after release"
-        required: true
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
-  set-release-version:
-    uses: ./.github/workflows/set-version.yml
-    with:
-      version: ${{ inputs.version }}
-
   build:
-    needs: set-release-version
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
         with:
-          ref: ${{ github.ref }}
+          distribution: temurin
+          java-version: 25
 
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@v6
 
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
+      - run: ./gradlew chiseledBuild
+
+      - uses: actions/upload-artifact@v7
         with:
-          java-version: "25"
-          distribution: "temurin"
-
-      - name: Build with Gradle
-        run: ./gradlew chiseledBuild
-
-      - name: Build Changelog
-        id: changelog
-        uses: mikepenz/release-changelog-builder-action@v6
-        with:
-          mode: COMMIT
-          toTag: ${{ github.ref }}
-          configurationJson: |
-            {
-              "template": "#{{CHANGELOG}}",
-              "commit_template": "- [`#{{SHORT_MERGE_SHA}}`](https://github.com/#{{OWNER}}/#{{REPO}}/commit/#{{MERGE_SHA}}) #{{TITLE}}",
-              "categories": [
-                { "title": "## Features", "labels": ["feat", "feature"] },
-                { "title": "## Fixes", "labels": ["fix", "bug"] },
-                { "title": "## Performance", "labels": ["perf"] },
-                { "title": "## Refactor", "labels": ["refactor"] },
-                { "title": "## Documentation", "labels": ["docs"] },
-                { "title": "## Build", "labels": ["build", "chore", "ci"] },
-                { "title": "## Other", "labels": [] }
-              ],
-              "empty_template": "no changes",
-              "label_extractor": [
-                {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-                  "on_property": "title",
-                  "target": "$1"
-                }
-              ],
-              "custom_placeholders": [
-                {
-                  "name": "SHORT_MERGE_SHA",
-                  "source": "MERGE_SHA",
-                  "transformer": {
-                    "pattern": "^([0-9a-f]{7})[0-9a-f]*$",
-                    "target": "$1"
-                  }
-                }
-              ]
-            }
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
-        run: |
-          VERSION="${{ inputs.version }}"
-          REPO="${{ github.repository }}"
-          DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
-
-          link() { echo "[${1}](${DOWNLOAD_URL}/anarchymod-mc-${1}-${VERSION}.jar)"; }
-          join() { local IFS=","; local out="$*"; echo "${out//,/, }"; }
-
-          mapfile -t MC_VERSIONS < <(for f in versions/*/gradle.properties; do
-            grep "^minecraft_version=" "$f" | cut -d= -f2
-          done | sort -V)
-
-          rows=()
-          group_key=""
-          group_links=()
-
-          flush_group() {
-            [ ${#group_links[@]} -eq 0 ] && return
-            rows+=("| ${group_key} | $(join "${group_links[@]}") |")
-          }
-
-          for v in "${MC_VERSIONS[@]}"; do
-            key=$(echo "$v" | cut -d. -f1,2)
-            if [ "$key" != "$group_key" ]; then
-              flush_group
-              group_key="$key"
-              group_links=()
-            fi
-            group_links+=("$(link "$v")")
-          done
-          flush_group
-
-          TABLE_ROWS=$(printf "%s\n" "${rows[@]}")
-
-          NOTES=$(cat <<EOF
-          ## Downloads
-
-          Grab the jar matching your Minecraft version. All builds are also attached below under Assets.
-
-          | Minecraft versions | Downloads |
-          |---|---|
-          ${TABLE_ROWS}
-
-          ${CHANGELOG}
-          EOF
-          )
-
-          shopt -s nullglob
-          ASSETS=(versions/*/build/libs/anarchymod-mc-*-"${VERSION}".jar)
-          shopt -u nullglob
-
-          if [ ${#ASSETS[@]} -eq 0 ]; then
-            echo "::error::No built jars matched versions/*/build/libs/anarchymod-mc-*-${VERSION}.jar - refusing to create an empty release." >&2
-            exit 1
-          fi
-
-          gh release create "${VERSION}" \
-            --title "AnarchyMod ${VERSION}" \
-            --notes "${NOTES}" \
-            "${ASSETS[@]}"
-
-      - name: Update README download links
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          : "${VERSION:?version input is required}"
-          REPO="${{ github.repository }}"
-          DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
-
-          link() { echo "[${1}](${DOWNLOAD_URL}/anarchymod-mc-${1}-${VERSION}.jar)"; }
-          join() { local IFS=","; local out="$*"; echo "${out//,/, }"; }
-
-          mapfile -t MC_VERSIONS < <(for f in versions/*/gradle.properties; do
-            grep "^minecraft_version=" "$f" | cut -d= -f2
-          done | sort -V)
-
-          rows=()
-          group_key=""
-          group_links=()
-          group_javas=()
-
-          flush_group() {
-            [ ${#group_links[@]} -eq 0 ] && return
-            mapfile -t uniq_java < <(printf "%s\n" "${group_javas[@]}" | sort -un)
-            java_label=$(IFS="/"; echo "${uniq_java[*]}")
-            rows+=("| $(join "${group_links[@]}") | ${java_label} |")
-          }
-
-          for v in "${MC_VERSIONS[@]}"; do
-            key=$(echo "$v" | cut -d. -f1,2)
-            jv=$(grep "^java_version=" "versions/$v/gradle.properties" | cut -d= -f2)
-            if [ "$key" != "$group_key" ]; then
-              flush_group
-              group_key="$key"
-              group_links=()
-              group_javas=()
-            fi
-            group_links+=("$(link "$v")")
-            group_javas+=("$jv")
-          done
-          flush_group
-
-          {
-            echo "| Minecraft versions | Required Java |"
-            echo "| :--- | :--- |"
-            printf "%s\n" "${rows[@]}"
-          } > /tmp/versions-table.md
-
-          awk -v tablefile=/tmp/versions-table.md '
-            BEGIN { while ((getline line < tablefile) > 0) table = table line "\n" }
-            /<!-- versions-table:start -->/ { print; printf "%s", table; skip=1; next }
-            /<!-- versions-table:end -->/ { skip=0 }
-            !skip { print }
-          ' README.md > README.md.new
-          mv README.md.new README.md
-
-      - name: Commit README
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: "chore(release): update README download links for ${{ inputs.version }}"
-          file_pattern: README.md
-
-  set-after-version:
-    needs: build
-    uses: ./.github/workflows/set-version.yml
-    with:
-      version: ${{ inputs.after-version }}
+          name: anarchymod-builds
+          path: |
+            versions/*/build/libs/anarchymod-mc-*.jar
+            !versions/*/build/libs/anarchymod-mc-*-sources.jar
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,165 +1,213 @@
-name: Build
+name: Publish Release
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release"
+        required: true
+      after-version:
+        description: "Snapshot version after release"
+        required: true
 
 jobs:
+  set-release-version:
+    uses: ./.github/workflows/set-version.yml
+    with:
+      version: ${{ inputs.version }}
+
   build:
+    needs: set-release-version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-java@v5
+      - name: Checkout repository
+        uses: actions/checkout@v7
         with:
-          distribution: temurin
-          java-version: 25
+          ref: ${{ github.ref }}
 
-      - uses: gradle/actions/setup-gradle@v6
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
-      - run: ./gradlew chiseledBuild
-
-      - uses: actions/upload-artifact@v7
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          name: anarchymod-mc-1.19.4
-          path: versions/1.19.4/build/libs/anarchymod-mc-1.19.4-*.jar
-          if-no-files-found: error
+          java-version: "25"
+          distribution: "temurin"
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.20
-          path: versions/1.20/build/libs/anarchymod-mc-1.20-*.jar
-          if-no-files-found: error
+      - name: Build with Gradle
+        run: ./gradlew chiseledBuild
 
-      - uses: actions/upload-artifact@v7
+      - name: Build Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v6
         with:
-          name: anarchymod-mc-1.20.1
-          path: versions/1.20.1/build/libs/anarchymod-mc-1.20.1-*.jar
-          if-no-files-found: error
+          mode: COMMIT
+          toTag: ${{ github.ref }}
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}",
+              "commit_template": "- [`#{{SHORT_MERGE_SHA}}`](https://github.com/#{{OWNER}}/#{{REPO}}/commit/#{{MERGE_SHA}}) #{{TITLE}}",
+              "categories": [
+                { "title": "## Features", "labels": ["feat", "feature"] },
+                { "title": "## Fixes", "labels": ["fix", "bug"] },
+                { "title": "## Performance", "labels": ["perf"] },
+                { "title": "## Refactor", "labels": ["refactor"] },
+                { "title": "## Documentation", "labels": ["docs"] },
+                { "title": "## Build", "labels": ["build", "chore", "ci"] },
+                { "title": "## Other", "labels": [] }
+              ],
+              "empty_template": "no changes",
+              "label_extractor": [
+                {
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+                  "on_property": "title",
+                  "target": "$1"
+                }
+              ],
+              "custom_placeholders": [
+                {
+                  "name": "SHORT_MERGE_SHA",
+                  "source": "MERGE_SHA",
+                  "transformer": {
+                    "pattern": "^([0-9a-f]{7})[0-9a-f]*$",
+                    "target": "$1"
+                  }
+                }
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.20.2
-          path: versions/1.20.2/build/libs/anarchymod-mc-1.20.2-*.jar
-          if-no-files-found: error
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+        run: |
+          VERSION="${{ inputs.version }}"
+          REPO="${{ github.repository }}"
+          DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.20.3
-          path: versions/1.20.3/build/libs/anarchymod-mc-1.20.3-*.jar
-          if-no-files-found: error
+          link() { echo "[${1}](${DOWNLOAD_URL}/anarchymod-mc-${1}-${VERSION}.jar)"; }
+          join() { local IFS=","; local out="$*"; echo "${out//,/, }"; }
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.20.4
-          path: versions/1.20.4/build/libs/anarchymod-mc-1.20.4-*.jar
-          if-no-files-found: error
+          mapfile -t MC_VERSIONS < <(for f in versions/*/gradle.properties; do
+            grep "^minecraft_version=" "$f" | cut -d= -f2
+          done | sort -V)
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.20.5
-          path: versions/1.20.5/build/libs/anarchymod-mc-1.20.5-*.jar
-          if-no-files-found: error
+          rows=()
+          group_key=""
+          group_links=()
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.20.6
-          path: versions/1.20.6/build/libs/anarchymod-mc-1.20.6-*.jar
-          if-no-files-found: error
+          flush_group() {
+            [ ${#group_links[@]} -eq 0 ] && return
+            rows+=("| ${group_key} | $(join "${group_links[@]}") |")
+          }
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21
-          path: versions/1.21/build/libs/anarchymod-mc-1.21-*.jar
-          if-no-files-found: error
+          for v in "${MC_VERSIONS[@]}"; do
+            key=$(echo "$v" | cut -d. -f1,2)
+            if [ "$key" != "$group_key" ]; then
+              flush_group
+              group_key="$key"
+              group_links=()
+            fi
+            group_links+=("$(link "$v")")
+          done
+          flush_group
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.1
-          path: versions/1.21.1/build/libs/anarchymod-mc-1.21.1-*.jar
-          if-no-files-found: error
+          TABLE_ROWS=$(printf "%s\n" "${rows[@]}")
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.2
-          path: versions/1.21.2/build/libs/anarchymod-mc-1.21.2-*.jar
-          if-no-files-found: error
+          NOTES=$(cat <<EOF
+          ## Downloads
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.3
-          path: versions/1.21.3/build/libs/anarchymod-mc-1.21.3-*.jar
-          if-no-files-found: error
+          Grab the jar matching your Minecraft version. All builds are also attached below under Assets.
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.4
-          path: versions/1.21.4/build/libs/anarchymod-mc-1.21.4-*.jar
-          if-no-files-found: error
+          | Minecraft versions | Downloads |
+          |---|---|
+          ${TABLE_ROWS}
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.5
-          path: versions/1.21.5/build/libs/anarchymod-mc-1.21.5-*.jar
-          if-no-files-found: error
+          ${CHANGELOG}
+          EOF
+          )
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.6
-          path: versions/1.21.6/build/libs/anarchymod-mc-1.21.6-*.jar
-          if-no-files-found: error
+          shopt -s nullglob
+          ASSETS=(versions/*/build/libs/anarchymod-mc-*-"${VERSION}".jar)
+          shopt -u nullglob
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.7
-          path: versions/1.21.7/build/libs/anarchymod-mc-1.21.7-*.jar
-          if-no-files-found: error
+          if [ ${#ASSETS[@]} -eq 0 ]; then
+            echo "::error::No built jars matched versions/*/build/libs/anarchymod-mc-*-${VERSION}.jar - refusing to create an empty release." >&2
+            exit 1
+          fi
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.8
-          path: versions/1.21.8/build/libs/anarchymod-mc-1.21.8-*.jar
-          if-no-files-found: error
+          gh release create "${VERSION}" \
+            --title "AnarchyMod ${VERSION}" \
+            --notes "${NOTES}" \
+            "${ASSETS[@]}"
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.9
-          path: versions/1.21.9/build/libs/anarchymod-mc-1.21.9-*.jar
-          if-no-files-found: error
+      - name: Update README download links
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          : "${VERSION:?version input is required}"
+          REPO="${{ github.repository }}"
+          DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.10
-          path: versions/1.21.10/build/libs/anarchymod-mc-1.21.10-*.jar
-          if-no-files-found: error
+          link() { echo "[${1}](${DOWNLOAD_URL}/anarchymod-mc-${1}-${VERSION}.jar)"; }
+          join() { local IFS=","; local out="$*"; echo "${out//,/, }"; }
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-1.21.11
-          path: versions/1.21.11/build/libs/anarchymod-mc-1.21.11-*.jar
-          if-no-files-found: error
+          mapfile -t MC_VERSIONS < <(for f in versions/*/gradle.properties; do
+            grep "^minecraft_version=" "$f" | cut -d= -f2
+          done | sort -V)
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-26.1
-          path: versions/26.1/build/libs/anarchymod-mc-26.1-*.jar
-          if-no-files-found: error
+          rows=()
+          group_key=""
+          group_links=()
+          group_javas=()
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-26.1.1
-          path: versions/26.1.1/build/libs/anarchymod-mc-26.1.1-*.jar
-          if-no-files-found: error
+          flush_group() {
+            [ ${#group_links[@]} -eq 0 ] && return
+            mapfile -t uniq_java < <(printf "%s\n" "${group_javas[@]}" | sort -un)
+            java_label=$(IFS="/"; echo "${uniq_java[*]}")
+            rows+=("| $(join "${group_links[@]}") | ${java_label} |")
+          }
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: anarchymod-mc-26.1.2
-          path: versions/26.1.2/build/libs/anarchymod-mc-26.1.2-*.jar
-          if-no-files-found: error
+          for v in "${MC_VERSIONS[@]}"; do
+            key=$(echo "$v" | cut -d. -f1,2)
+            jv=$(grep "^java_version=" "versions/$v/gradle.properties" | cut -d= -f2)
+            if [ "$key" != "$group_key" ]; then
+              flush_group
+              group_key="$key"
+              group_links=()
+              group_javas=()
+            fi
+            group_links+=("$(link "$v")")
+            group_javas+=("$jv")
+          done
+          flush_group
 
-      - uses: actions/upload-artifact@v7
+          {
+            echo "| Minecraft versions | Required Java |"
+            echo "| :--- | :--- |"
+            printf "%s\n" "${rows[@]}"
+          } > /tmp/versions-table.md
+
+          awk -v tablefile=/tmp/versions-table.md '
+            BEGIN { while ((getline line < tablefile) > 0) table = table line "\n" }
+            /<!-- versions-table:start -->/ { print; printf "%s", table; skip=1; next }
+            /<!-- versions-table:end -->/ { skip=0 }
+            !skip { print }
+          ' README.md > README.md.new
+          mv README.md.new README.md
+
+      - name: Commit README
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          name: anarchymod-mc-26.2
-          path: versions/26.2/build/libs/anarchymod-mc-26.2-*.jar
-          if-no-files-found: error
+          commit_message: "chore(release): update README download links for ${{ inputs.version }}"
+          file_pattern: README.md
+
+  set-after-version:
+    needs: build
+    uses: ./.github/workflows/set-version.yml
+    with:
+      version: ${{ inputs.after-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release'
+        description: "Version to release"
         required: true
       after-version:
-        description: 'Snapshot version after release'
+        description: "Snapshot version after release"
         required: true
 
 jobs:
@@ -33,8 +33,8 @@ jobs:
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '25'
-          distribution: 'temurin'
+          java-version: "25"
+          distribution: "temurin"
 
       - name: Build with Gradle
         run: ./gradlew chiseledBuild
@@ -89,67 +89,122 @@ jobs:
           REPO="${{ github.repository }}"
           DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
+          link() { echo "[${1}](${DOWNLOAD_URL}/anarchymod-mc-${1}-${VERSION}.jar)"; }
+          join() { local IFS=","; local out="$*"; echo "${out//,/, }"; }
+
+          mapfile -t MC_VERSIONS < <(for f in versions/*/gradle.properties; do
+            grep "^minecraft_version=" "$f" | cut -d= -f2
+          done | sort -V)
+
+          rows=()
+          group_key=""
+          group_links=()
+
+          flush_group() {
+            [ ${#group_links[@]} -eq 0 ] && return
+            rows+=("| ${group_key} | $(join "${group_links[@]}") |")
+          }
+
+          for v in "${MC_VERSIONS[@]}"; do
+            key=$(echo "$v" | cut -d. -f1,2)
+            if [ "$key" != "$group_key" ]; then
+              flush_group
+              group_key="$key"
+              group_links=()
+            fi
+            group_links+=("$(link "$v")")
+          done
+          flush_group
+
+          TABLE_ROWS=$(printf "%s\n" "${rows[@]}")
+
           NOTES=$(cat <<EOF
           ## Downloads
 
-          | Minecraft Version | Download |
+          Grab the jar matching your Minecraft version. All builds are also attached below under Assets.
+
+          | Minecraft versions | Downloads |
           |---|---|
-          | 1.19.4 | [\`anarchymod-mc-1.19.4-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.19.4-${VERSION}.jar) |
-          | 1.20 | [\`anarchymod-mc-1.20-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.20-${VERSION}.jar) |
-          | 1.20.1 | [\`anarchymod-mc-1.20.1-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.20.1-${VERSION}.jar) |
-          | 1.20.2 | [\`anarchymod-mc-1.20.2-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.20.2-${VERSION}.jar) |
-          | 1.20.3 | [\`anarchymod-mc-1.20.3-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.20.3-${VERSION}.jar) |
-          | 1.20.4 | [\`anarchymod-mc-1.20.4-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.20.4-${VERSION}.jar) |
-          | 1.20.5 | [\`anarchymod-mc-1.20.5-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.20.5-${VERSION}.jar) |
-          | 1.20.6 | [\`anarchymod-mc-1.20.6-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.20.6-${VERSION}.jar) |
-          | 1.21 | [\`anarchymod-mc-1.21-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21-${VERSION}.jar) |
-          | 1.21.1 | [\`anarchymod-mc-1.21.1-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.1-${VERSION}.jar) |
-          | 1.21.2 | [\`anarchymod-mc-1.21.2-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.2-${VERSION}.jar) |
-          | 1.21.3 | [\`anarchymod-mc-1.21.3-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.3-${VERSION}.jar) |
-          | 1.21.4 | [\`anarchymod-mc-1.21.4-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.4-${VERSION}.jar) |
-          | 1.21.5 | [\`anarchymod-mc-1.21.5-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.5-${VERSION}.jar) |
-          | 1.21.6 | [\`anarchymod-mc-1.21.6-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.6-${VERSION}.jar) |
-          | 1.21.7 | [\`anarchymod-mc-1.21.7-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.7-${VERSION}.jar) |
-          | 1.21.8 | [\`anarchymod-mc-1.21.8-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.8-${VERSION}.jar) |
-          | 1.21.9 | [\`anarchymod-mc-1.21.9-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.9-${VERSION}.jar) |
-          | 1.21.10 | [\`anarchymod-mc-1.21.10-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.10-${VERSION}.jar) |
-          | 1.21.11 | [\`anarchymod-mc-1.21.11-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-1.21.11-${VERSION}.jar) |
-          | 26.1 | [\`anarchymod-mc-26.1-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-26.1-${VERSION}.jar) |
-          | 26.1.1 | [\`anarchymod-mc-26.1.1-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-26.1.1-${VERSION}.jar) |
-          | 26.1.2 | [\`anarchymod-mc-26.1.2-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-26.1.2-${VERSION}.jar) |
-          | 26.2 | [\`anarchymod-mc-26.2-${VERSION}.jar\`](${DOWNLOAD_URL}/anarchymod-mc-26.2-${VERSION}.jar) |
+          ${TABLE_ROWS}
 
           ${CHANGELOG}
           EOF
           )
 
+          shopt -s nullglob
+          ASSETS=(versions/*/build/libs/anarchymod-mc-*-"${VERSION}".jar)
+          shopt -u nullglob
+
+          if [ ${#ASSETS[@]} -eq 0 ]; then
+            echo "::error::No built jars matched versions/*/build/libs/anarchymod-mc-*-${VERSION}.jar - refusing to create an empty release." >&2
+            exit 1
+          fi
+
           gh release create "${VERSION}" \
             --title "AnarchyMod ${VERSION}" \
             --notes "${NOTES}" \
-            versions/1.19.4/build/libs/anarchymod-mc-1.19.4-${VERSION}.jar \
-            versions/1.20/build/libs/anarchymod-mc-1.20-${VERSION}.jar \
-            versions/1.20.1/build/libs/anarchymod-mc-1.20.1-${VERSION}.jar \
-            versions/1.20.2/build/libs/anarchymod-mc-1.20.2-${VERSION}.jar \
-            versions/1.20.3/build/libs/anarchymod-mc-1.20.3-${VERSION}.jar \
-            versions/1.20.4/build/libs/anarchymod-mc-1.20.4-${VERSION}.jar \
-            versions/1.20.5/build/libs/anarchymod-mc-1.20.5-${VERSION}.jar \
-            versions/1.20.6/build/libs/anarchymod-mc-1.20.6-${VERSION}.jar \
-            versions/1.21/build/libs/anarchymod-mc-1.21-${VERSION}.jar \
-            versions/1.21.1/build/libs/anarchymod-mc-1.21.1-${VERSION}.jar \
-            versions/1.21.2/build/libs/anarchymod-mc-1.21.2-${VERSION}.jar \
-            versions/1.21.3/build/libs/anarchymod-mc-1.21.3-${VERSION}.jar \
-            versions/1.21.4/build/libs/anarchymod-mc-1.21.4-${VERSION}.jar \
-            versions/1.21.5/build/libs/anarchymod-mc-1.21.5-${VERSION}.jar \
-            versions/1.21.6/build/libs/anarchymod-mc-1.21.6-${VERSION}.jar \
-            versions/1.21.7/build/libs/anarchymod-mc-1.21.7-${VERSION}.jar \
-            versions/1.21.8/build/libs/anarchymod-mc-1.21.8-${VERSION}.jar \
-            versions/1.21.9/build/libs/anarchymod-mc-1.21.9-${VERSION}.jar \
-            versions/1.21.10/build/libs/anarchymod-mc-1.21.10-${VERSION}.jar \
-            versions/1.21.11/build/libs/anarchymod-mc-1.21.11-${VERSION}.jar \
-            versions/26.1/build/libs/anarchymod-mc-26.1-${VERSION}.jar \
-            versions/26.1.1/build/libs/anarchymod-mc-26.1.1-${VERSION}.jar \
-            versions/26.1.2/build/libs/anarchymod-mc-26.1.2-${VERSION}.jar \
-            versions/26.2/build/libs/anarchymod-mc-26.2-${VERSION}.jar
+            "${ASSETS[@]}"
+
+      - name: Update README download links
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          : "${VERSION:?version input is required}"
+          REPO="${{ github.repository }}"
+          DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+          link() { echo "[${1}](${DOWNLOAD_URL}/anarchymod-mc-${1}-${VERSION}.jar)"; }
+          join() { local IFS=","; local out="$*"; echo "${out//,/, }"; }
+
+          mapfile -t MC_VERSIONS < <(for f in versions/*/gradle.properties; do
+            grep "^minecraft_version=" "$f" | cut -d= -f2
+          done | sort -V)
+
+          rows=()
+          group_key=""
+          group_links=()
+          group_javas=()
+
+          flush_group() {
+            [ ${#group_links[@]} -eq 0 ] && return
+            mapfile -t uniq_java < <(printf "%s\n" "${group_javas[@]}" | sort -un)
+            java_label=$(IFS="/"; echo "${uniq_java[*]}")
+            rows+=("| $(join "${group_links[@]}") | ${java_label} |")
+          }
+
+          for v in "${MC_VERSIONS[@]}"; do
+            key=$(echo "$v" | cut -d. -f1,2)
+            jv=$(grep "^java_version=" "versions/$v/gradle.properties" | cut -d= -f2)
+            if [ "$key" != "$group_key" ]; then
+              flush_group
+              group_key="$key"
+              group_links=()
+              group_javas=()
+            fi
+            group_links+=("$(link "$v")")
+            group_javas+=("$jv")
+          done
+          flush_group
+
+          {
+            echo "| Minecraft versions | Required Java |"
+            echo "| :--- | :--- |"
+            printf "%s\n" "${rows[@]}"
+          } > /tmp/versions-table.md
+
+          awk -v tablefile=/tmp/versions-table.md '
+            BEGIN { while ((getline line < tablefile) > 0) table = table line "\n" }
+            /<!-- versions-table:start -->/ { print; printf "%s", table; skip=1; next }
+            /<!-- versions-table:end -->/ { skip=0 }
+            !skip { print }
+          ' README.md > README.md.new
+          mv README.md.new README.md
+
+      - name: Commit README
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore(release): update README download links for ${{ inputs.version }}"
+          file_pattern: README.md
 
   set-after-version:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+          VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
         run: |
-          VERSION="${{ inputs.version }}"
           REPO="${{ github.repository }}"
           DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
@@ -148,9 +149,8 @@ jobs:
       - name: Update README download links
         env:
           VERSION: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
         run: |
-          : "${VERSION:?version input is required}"
-          REPO="${{ github.repository }}"
           DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
           link() { echo "[${1}](${DOWNLOAD_URL}/anarchymod-mc-${1}-${VERSION}.jar)"; }

--- a/.github/workflows/set-version.yml
+++ b/.github/workflows/set-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to set'
+        description: "Version to set"
         required: true
   workflow_call:
     inputs:
@@ -32,4 +32,4 @@ jobs:
       - name: Commit Version
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: 'chore(release): bump version to ${{ inputs.version }}'
+          commit_message: "chore(release): bump version to ${{ inputs.version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ gradle-app.setting
 *.ipr
 
 **/run/
+/versions/*/logs

--- a/README.md
+++ b/README.md
@@ -3,42 +3,37 @@
 [![Build](https://github.com/6b6t/AnarchyMod/actions/workflows/build.yml/badge.svg)](https://github.com/6b6t/AnarchyMod/actions/workflows/build.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-🔓 The Minecraft mod required to play on 6b6t — bypass Mojang's ban of the world's biggest anarchy server.
+🔓 The Minecraft mod required to play on 6b6t - bypass Mojang's ban of the world's biggest anarchy server.
 
 ## Features
 
-- **Server unblocking** — bypasses Mojang's blocked server list for known anarchy servers
-- **Auto server list** — automatically adds 6b6t to your server list if not already present
-- **Join notification** — sends a lightweight packet to the server on join for analytics
+- **Server unblocking** - bypasses Mojang's blocked server list for known anarchy servers
+- **Auto server list** - automatically adds 6b6t to your server list if not already present
+- **Join notification** - sends a lightweight packet to the server on join for analytics
 
 ## Supported Minecraft Versions
 
-| Minecraft | Module       |
-|-----------|--------------|
-| 1.19.4    | `mc-1.19.4`  |
-| 1.20      | `mc-1.20`    |
-| 1.20.1    | `mc-1.20.1`  |
-| 1.20.2    | `mc-1.20.2`  |
-| 1.20.3    | `mc-1.20.3`  |
-| 1.20.4    | `mc-1.20.4`  |
-| 1.20.5    | `mc-1.20.5`  |
-| 1.20.6    | `mc-1.20.6`  |
-| 1.21      | `mc-1.21`    |
-| 1.21.1    | `mc-1.21.1`  |
-| 1.21.2    | `mc-1.21.2`  |
-| 1.21.3    | `mc-1.21.3`  |
-| 1.21.4    | `mc-1.21.4`  |
-| 1.21.5    | `mc-1.21.5`  |
-| 1.21.6    | `mc-1.21.6`  |
-| 1.21.7    | `mc-1.21.7`  |
-| 1.21.8    | `mc-1.21.8`  |
-| 1.21.9    | `mc-1.21.9`  |
-| 1.21.10   | `mc-1.21.10` |
-| 1.21.11   | `mc-1.21.11` |
-| 26.1      | `mc-26.1`    |
-| 26.1.1    | `mc-26.1.1`  |
-| 26.1.2    | `mc-26.1.2`  |
-| 26.2      | `mc-26.2`    |
+Click a version below to download its jar from the latest release.
+
+<!-- versions-table:start -->
+| Minecraft versions | Required Java |
+| :--- | :--- |
+| [1.9.4](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.9.4-1.3.2.jar) | 8 |
+| [1.10.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.10.2-1.3.2.jar) | 8 |
+| [1.11.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.11.2-1.3.2.jar) | 8 |
+| [1.12.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.12.2-1.3.2.jar) | 8 |
+| [1.13.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.13.2-1.3.2.jar) | 8 |
+| [1.14.3](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.14.3-1.3.2.jar), [1.14.4](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.14.4-1.3.2.jar) | 8 |
+| [1.15](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.15-1.3.2.jar), [1.15.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.15.1-1.3.2.jar), [1.15.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.15.2-1.3.2.jar) | 8 |
+| [1.16](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.16-1.3.2.jar), [1.16.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.16.1-1.3.2.jar), [1.16.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.16.2-1.3.2.jar), [1.16.3](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.16.3-1.3.2.jar), [1.16.4](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.16.4-1.3.2.jar), [1.16.5](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.16.5-1.3.2.jar) | 8 |
+| [1.17](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.17-1.3.2.jar), [1.17.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.17.1-1.3.2.jar) | 17 |
+| [1.18](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.18-1.3.2.jar), [1.18.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.18.1-1.3.2.jar), [1.18.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.18.2-1.3.2.jar) | 17 |
+| [1.19](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.19-1.3.2.jar), [1.19.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.19.1-1.3.2.jar), [1.19.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.19.2-1.3.2.jar), [1.19.3](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.19.3-1.3.2.jar), [1.19.4](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.19.4-1.3.2.jar) | 17 |
+| [1.20](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.20-1.3.2.jar), [1.20.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.20.1-1.3.2.jar), [1.20.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.20.2-1.3.2.jar), [1.20.3](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.20.3-1.3.2.jar), [1.20.4](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.20.4-1.3.2.jar), [1.20.5](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.20.5-1.3.2.jar), [1.20.6](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.20.6-1.3.2.jar) | 17/21 |
+| [1.21](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21-1.3.2.jar), [1.21.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.1-1.3.2.jar), [1.21.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.2-1.3.2.jar), [1.21.3](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.3-1.3.2.jar), [1.21.4](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.4-1.3.2.jar), [1.21.5](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.5-1.3.2.jar), [1.21.6](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.6-1.3.2.jar), [1.21.7](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.7-1.3.2.jar), [1.21.8](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.8-1.3.2.jar), [1.21.9](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.9-1.3.2.jar), [1.21.10](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.10-1.3.2.jar), [1.21.11](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-1.21.11-1.3.2.jar) | 21 |
+| [26.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-26.1-1.3.2.jar), [26.1.1](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-26.1.1-1.3.2.jar), [26.1.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-26.1.2-1.3.2.jar) | 25 |
+| [26.2](https://github.com/6b6t/AnarchyMod/releases/download/1.3.2/anarchymod-mc-26.2-1.3.2.jar) | 25 |
+<!-- versions-table:end -->
 
 ## Installation
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: AnarchyMod
-description: 🔓 The Minecraft mod required to play on 6b6t — bypass Mojang's ban of the world's biggest anarchy server.
+description: 🔓 The Minecraft mod required to play on 6b6t - bypass Mojang's ban of the world's biggest anarchy server.
 theme: jekyll-theme-hacker
 
 # The release jar lives on the Releases page, so hide the source zip/tar buttons.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,12 +14,15 @@ base {
     archivesName.set("anarchymod-mc-${minecraftVersion}")
 }
 
+// for fallback since 6 requires 17+ and 5 requires <17
+val junitJupiterVersion = if (javaVersion >= 17) "6.1.2" else "5.10.3"
+
 dependencies {
     minecraft("com.mojang:minecraft:$minecraftVersion")
     mappings(loom.officialMojangMappings())
     modImplementation("net.fabricmc:fabric-loader:$loaderVersion")
     implementation("com.google.code.gson:gson:2.14.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:6.1.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
@@ -55,7 +58,10 @@ tasks.processResources {
 
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
-    options.release.set(javaVersion)
+    // javac only gained --release in JDK 9; JDK 8 toolchains already target their own version.
+    if (javaVersion >= 9) {
+        options.release.set(javaVersion)
+    }
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ tasks.processResources {
 
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
-    // javac only gained --release in JDK 9; JDK 8 toolchains already target their own version.
+    // javac only gained --release in JDK 9
     if (javaVersion >= 9) {
         options.release.set(javaVersion)
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,8 +12,23 @@ plugins {
 
 stonecutter {
     create(rootProject) {
+        val yarnLegacy = arrayOf(
+            "1.9.4",
+            "1.10.2",
+            "1.11.2",
+            "1.12.2",
+            "1.13.2",
+            "1.14.3"
+        )
+
         val legacy = arrayOf(
-            "1.19.4", "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4",
+            "1.14.4",
+            "1.15", "1.15.1", "1.15.2",
+            "1.16", "1.16.1", "1.16.2", "1.16.3", "1.16.4", "1.16.5",
+            "1.17", "1.17.1",
+            "1.18", "1.18.1", "1.18.2",
+            "1.19", "1.19.1", "1.19.2", "1.19.3", "1.19.4",
+            "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4",
             "1.20.5", "1.20.6",
             "1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4",
             "1.21.5", "1.21.6", "1.21.7",
@@ -21,6 +36,7 @@ stonecutter {
         )
         val modern = arrayOf("26.1", "26.1.1", "26.1.2", "26.2")
 
+        versions(*yarnLegacy).buildscript("yarn-build.gradle.kts")
         versions(*legacy).buildscript("build.gradle.kts")
         versions(*modern).buildscript("modern-build.gradle.kts")
     }

--- a/src/main/java/net/blockhost/anarchymod/Domains.java
+++ b/src/main/java/net/blockhost/anarchymod/Domains.java
@@ -6,12 +6,24 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.net.IDN;
+//? if >=1.19.4 {
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+//?} else {
+/*import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.CompletableFuture;
+*///?}
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -25,11 +37,10 @@ public final class Domains {
     private static final int MAX_RESPONSE_LENGTH = 1_048_576;
     private static final int MAX_REMOTE_DOMAINS = 4_096;
 
-    private static final Set<String> DEFAULT = Set.of(
-        "*.6b6t.org", "*.10b10t.org", "*.6b6t.cc", "*.6b6t.me",
-        "*.7b7t.me", "*.8b8t.org", "*.8b8t.xyz", "*.alacity.net",
-        "*.anarchypvp.pw", "*.l2x9.org", "*.simpleanarchy.org"
-    );
+    private static final Set<String> DEFAULT = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "*.6b6t.org", "*.10b10t.org", "*.6b6t.cc", "*.6b6t.me",
+            "*.7b7t.me", "*.8b8t.org", "*.8b8t.xyz", "*.alacity.net",
+            "*.anarchypvp.pw", "*.l2x9.org", "*.simpleanarchy.org")));
 
     private static final Gson GSON = new Gson();
     private static final AtomicBoolean REMOTE_LOAD_STARTED = new AtomicBoolean();
@@ -44,38 +55,86 @@ public final class Domains {
         }
     }
 
+    // ? if >=1.19.4 {
     private static void loadRemoteAsync() {
         try {
             HttpClient client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(5))
-                .build();
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build();
             HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(DOMAINS_URL))
-                .timeout(Duration.ofSeconds(10))
-                .header("Accept", "application/json")
-                .GET()
-                .build();
+                    .uri(URI.create(DOMAINS_URL))
+                    .timeout(Duration.ofSeconds(10))
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
 
             client.sendAsync(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
-                .thenAccept(Domains::applyRemoteResponse)
-                .exceptionally(error -> {
-                    LOGGER.warning("Failed to load domains from remote, using defaults: " + error.getMessage());
-                    return null;
-                });
+                    .thenAccept(response -> applyRemoteResponse(response.statusCode(), response.body()))
+                    .exceptionally(error -> {
+                        LOGGER.warning("Failed to load domains from remote, using defaults: " + error.getMessage());
+                        return null;
+                    });
         } catch (RuntimeException error) {
-            // Domain checks must remain available even if the HTTP client cannot be initialized.
+            // Domain checks must remain available even if the HTTP client cannot be
+            // initialized.
             LOGGER.warning("Failed to load domains from remote, using defaults: " + error.getMessage());
         }
     }
+    // ?} else {
+    /*
+     * private static void loadRemoteAsync() {
+     * CompletableFuture.runAsync(() -> {
+     * HttpURLConnection connection = null;
+     * try {
+     * connection = (HttpURLConnection) new URL(DOMAINS_URL).openConnection();
+     * connection.setRequestMethod("GET");
+     * connection.setRequestProperty("Accept", "application/json");
+     * connection.setConnectTimeout(5_000);
+     * connection.setReadTimeout(10_000);
+     *
+     * int statusCode = connection.getResponseCode();
+     * InputStream stream = statusCode == 200 ? connection.getInputStream() :
+     * connection.getErrorStream();
+     * applyRemoteResponse(statusCode, readBody(stream));
+     * } catch (IOException | RuntimeException error) {
+     * // Domain checks must remain available even if the HTTP client cannot be
+     * initialized.
+     * LOGGER.warning("Failed to load domains from remote, using defaults: " +
+     * error.getMessage());
+     * } finally {
+     * if (connection != null) {
+     * connection.disconnect();
+     * }
+     * }
+     * });
+     * }
+     *
+     * private static String readBody(InputStream stream) throws IOException {
+     * if (stream == null) {
+     * return "";
+     * }
+     *
+     * StringBuilder builder = new StringBuilder();
+     * try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream,
+     * StandardCharsets.UTF_8))) {
+     * char[] buffer = new char[8_192];
+     * int read;
+     * while (builder.length() <= MAX_RESPONSE_LENGTH && (read =
+     * reader.read(buffer)) != -1) {
+     * builder.append(buffer, 0, read);
+     * }
+     * }
+     * return builder.toString();
+     * }
+     */// ?}
 
-    private static void applyRemoteResponse(HttpResponse<String> response) {
-        if (response.statusCode() != 200) {
-            LOGGER.warning("Failed to load domains from remote, using defaults: HTTP " + response.statusCode());
+    private static void applyRemoteResponse(int statusCode, String body) {
+        if (statusCode != 200) {
+            LOGGER.warning("Failed to load domains from remote, using defaults: HTTP " + statusCode);
             return;
         }
 
-        String body = response.body();
-        if (body == null || body.isBlank() || body.length() > MAX_RESPONSE_LENGTH) {
+        if (body == null || body.trim().isEmpty() || body.length() > MAX_RESPONSE_LENGTH) {
             LOGGER.warning("Failed to load domains from remote, using defaults: response is empty or too large");
             return;
         }
@@ -105,7 +164,7 @@ public final class Domains {
         }
 
         // Readers always see either the old or the complete new immutable snapshot.
-        domains = Set.copyOf(updated);
+        domains = Collections.unmodifiableSet(updated);
     }
 
     public static boolean contains(String input) {
@@ -187,7 +246,8 @@ public final class Domains {
         }
 
         try {
-            // IPv6 literals contain colons and are not valid IDNs, but preserving them is safe.
+            // IPv6 literals contain colons and are not valid IDNs, but preserving them is
+            // safe.
             if (host.indexOf(':') >= 0) {
                 return host.toLowerCase(Locale.ROOT);
             }

--- a/src/main/java/net/blockhost/anarchymod/Domains.java
+++ b/src/main/java/net/blockhost/anarchymod/Domains.java
@@ -38,9 +38,10 @@ public final class Domains {
     private static final int MAX_REMOTE_DOMAINS = 4_096;
 
     private static final Set<String> DEFAULT = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "*.6b6t.org", "*.10b10t.org", "*.6b6t.cc", "*.6b6t.me",
-            "*.7b7t.me", "*.8b8t.org", "*.8b8t.xyz", "*.alacity.net",
-            "*.anarchypvp.pw", "*.l2x9.org", "*.simpleanarchy.org")));
+        "*.6b6t.org", "*.10b10t.org", "*.6b6t.cc", "*.6b6t.me",
+        "*.7b7t.me", "*.8b8t.org", "*.8b8t.xyz", "*.alacity.net",
+        "*.anarchypvp.pw", "*.l2x9.org", "*.simpleanarchy.org"
+    )));
 
     private static final Gson GSON = new Gson();
     private static final AtomicBoolean REMOTE_LOAD_STARTED = new AtomicBoolean();
@@ -55,78 +56,71 @@ public final class Domains {
         }
     }
 
-    // ? if >=1.19.4 {
+    //? if >=1.19.4 {
     private static void loadRemoteAsync() {
         try {
             HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(5))
-                    .build();
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(DOMAINS_URL))
-                    .timeout(Duration.ofSeconds(10))
-                    .header("Accept", "application/json")
-                    .GET()
-                    .build();
+                .uri(URI.create(DOMAINS_URL))
+                .timeout(Duration.ofSeconds(10))
+                .header("Accept", "application/json")
+                .GET()
+                .build();
 
             client.sendAsync(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8))
-                    .thenAccept(response -> applyRemoteResponse(response.statusCode(), response.body()))
-                    .exceptionally(error -> {
-                        LOGGER.warning("Failed to load domains from remote, using defaults: " + error.getMessage());
-                        return null;
-                    });
+                .thenAccept(response -> applyRemoteResponse(response.statusCode(), response.body()))
+                .exceptionally(error -> {
+                    LOGGER.warning("Failed to load domains from remote, using defaults: " + error.getMessage());
+                    return null;
+                });
         } catch (RuntimeException error) {
-            // Domain checks must remain available even if the HTTP client cannot be
-            // initialized.
+            // Domain checks must remain available even if the HTTP client cannot be initialized.
             LOGGER.warning("Failed to load domains from remote, using defaults: " + error.getMessage());
         }
     }
-    // ?} else {
-    /*
-     * private static void loadRemoteAsync() {
-     * CompletableFuture.runAsync(() -> {
-     * HttpURLConnection connection = null;
-     * try {
-     * connection = (HttpURLConnection) new URL(DOMAINS_URL).openConnection();
-     * connection.setRequestMethod("GET");
-     * connection.setRequestProperty("Accept", "application/json");
-     * connection.setConnectTimeout(5_000);
-     * connection.setReadTimeout(10_000);
-     *
-     * int statusCode = connection.getResponseCode();
-     * InputStream stream = statusCode == 200 ? connection.getInputStream() :
-     * connection.getErrorStream();
-     * applyRemoteResponse(statusCode, readBody(stream));
-     * } catch (IOException | RuntimeException error) {
-     * // Domain checks must remain available even if the HTTP client cannot be
-     * initialized.
-     * LOGGER.warning("Failed to load domains from remote, using defaults: " +
-     * error.getMessage());
-     * } finally {
-     * if (connection != null) {
-     * connection.disconnect();
-     * }
-     * }
-     * });
-     * }
-     *
-     * private static String readBody(InputStream stream) throws IOException {
-     * if (stream == null) {
-     * return "";
-     * }
-     *
-     * StringBuilder builder = new StringBuilder();
-     * try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream,
-     * StandardCharsets.UTF_8))) {
-     * char[] buffer = new char[8_192];
-     * int read;
-     * while (builder.length() <= MAX_RESPONSE_LENGTH && (read =
-     * reader.read(buffer)) != -1) {
-     * builder.append(buffer, 0, read);
-     * }
-     * }
-     * return builder.toString();
-     * }
-     */// ?}
+    //?} else {
+    /*private static void loadRemoteAsync() {
+        CompletableFuture.runAsync(() -> {
+            HttpURLConnection connection = null;
+            try {
+                connection = (HttpURLConnection) new URL(DOMAINS_URL).openConnection();
+                connection.setRequestMethod("GET");
+                connection.setRequestProperty("Accept", "application/json");
+                connection.setConnectTimeout(5_000);
+                connection.setReadTimeout(10_000);
+
+                int statusCode = connection.getResponseCode();
+                InputStream stream = statusCode == 200 ? connection.getInputStream() : connection.getErrorStream();
+                applyRemoteResponse(statusCode, readBody(stream));
+            } catch (IOException | RuntimeException error) {
+                // Domain checks must remain available even if the HTTP client cannot be initialized.
+                LOGGER.warning("Failed to load domains from remote, using defaults: " + error.getMessage());
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
+        });
+    }
+
+    private static String readBody(InputStream stream) throws IOException {
+        if (stream == null) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            char[] buffer = new char[8_192];
+            int read;
+            while (builder.length() <= MAX_RESPONSE_LENGTH && (read = reader.read(buffer)) != -1) {
+                builder.append(buffer, 0, read);
+            }
+        }
+        return builder.toString();
+    }
+    *///?}
 
     private static void applyRemoteResponse(int statusCode, String body) {
         if (statusCode != 200) {
@@ -246,8 +240,7 @@ public final class Domains {
         }
 
         try {
-            // IPv6 literals contain colons and are not valid IDNs, but preserving them is
-            // safe.
+            // IPv6 literals contain colons and are not valid IDNs, but preserving them is safe.
             if (host.indexOf(':') >= 0) {
                 return host.toLowerCase(Locale.ROOT);
             }

--- a/src/main/java/net/blockhost/anarchymod/JoinPayload.java
+++ b/src/main/java/net/blockhost/anarchymod/JoinPayload.java
@@ -30,49 +30,36 @@ import net.minecraft.resources.Identifier;
 
 public final class JoinPayload {
 
-    // ? if >=1.21.11 {
+    //? if >=1.21.11 {
     public static final Identifier ID = Identifier.fromNamespaceAndPath("anarchymod", "join");
-    // ? } elif >=1.21.7 {
-    /*
-     * public static final ResourceLocation ID =
-     * ResourceLocation.fromNamespaceAndPath("anarchymod", "join");
-     */// ?} elif >=1.19.4 {
-    /*
-     * public static final ResourceLocation ID =
-     * ResourceLocation.tryBuild("anarchymod", "join");
-     */// ?} elif >=1.14.4 {
-    /*
-     * public static final ResourceLocation ID = new ResourceLocation("anarchymod",
-     * "join");
-     */// ?} else {
-    /*
-     * public static final Identifier ID = new Identifier("anarchymod", "join");
-     */// ?}
+    //? } elif >=1.21.7 {
+    /*public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath("anarchymod", "join");
+    *///?} elif >=1.19.4 {
+    /*public static final ResourceLocation ID = ResourceLocation.tryBuild("anarchymod", "join");
+    *///?} elif >=1.14.4 {
+    /*public static final ResourceLocation ID = new ResourceLocation("anarchymod", "join");
+    *///?} else {
+    /*public static final Identifier ID = new Identifier("anarchymod", "join");
+    *///?}
 
     private JoinPayload() {
     }
 
-    // ? if <=1.12.2 {
-    /*
-     * public static CustomPayloadC2SPacket createPacket() {
-     * return new CustomPayloadC2SPacket(ID.toString(), new
-     * PacketByteBuf(Unpooled.EMPTY_BUFFER));
-     * }
-     */// ?} elif <1.14.4 {
-    /*
-     * public static CustomPayloadC2SPacket createPacket() {
-     * return new CustomPayloadC2SPacket(ID, new
-     * PacketByteBuf(Unpooled.EMPTY_BUFFER));
-     * }
-     */// ?} elif <1.20.2 {
-    /*
-     * public static ServerboundCustomPayloadPacket createPacket() {
-     * return new ServerboundCustomPayloadPacket(ID, new
-     * FriendlyByteBuf(Unpooled.EMPTY_BUFFER));
-     * }
-     */// ?} else {
+    //? if <=1.12.2 {
+    /*public static CustomPayloadC2SPacket createPacket() {
+        return new CustomPayloadC2SPacket(ID.toString(), new PacketByteBuf(Unpooled.EMPTY_BUFFER));
+    }
+    *///?} elif <1.14.4 {
+    /*public static CustomPayloadC2SPacket createPacket() {
+        return new CustomPayloadC2SPacket(ID, new PacketByteBuf(Unpooled.EMPTY_BUFFER));
+    }
+    *///?} elif <1.20.2 {
+    /*public static ServerboundCustomPayloadPacket createPacket() {
+        return new ServerboundCustomPayloadPacket(ID, new FriendlyByteBuf(Unpooled.EMPTY_BUFFER));
+    }
+    *///?} else {
     public static ServerboundCustomPayloadPacket createPacket() {
         return new ServerboundCustomPayloadPacket(new DiscardedPayload(ID));
     }
-    // ?}
+    //?}
 }

--- a/src/main/java/net/blockhost/anarchymod/JoinPayload.java
+++ b/src/main/java/net/blockhost/anarchymod/JoinPayload.java
@@ -1,6 +1,18 @@
 package net.blockhost.anarchymod;
 
-//? if <1.20.2 {
+//? if <=1.12.2 {
+/*import io.netty.buffer.Unpooled;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.util.PacketByteBuf;
+*///?} elif <=1.13.2 {
+/*import io.netty.buffer.Unpooled;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.util.PacketByteBuf;
+*///?} elif <1.14.4 {
+/*import io.netty.buffer.Unpooled;
+import net.minecraft.server.network.packet.CustomPayloadC2SPacket;
+import net.minecraft.util.PacketByteBuf;
+*///?} elif <1.20.2 {
 /*import io.netty.buffer.Unpooled;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
@@ -10,28 +22,57 @@ import net.minecraft.network.protocol.common.custom.DiscardedPayload;
 //?}
 //? if >=1.21.11 {
 import net.minecraft.resources.Identifier;
-//? } else {
+//? } elif >=1.14.4 {
 /*import net.minecraft.resources.ResourceLocation;
+*///?} else {
+/*import net.minecraft.util.Identifier;
 *///?}
 
 public final class JoinPayload {
 
-    //? if >=1.21.11 {
+    // ? if >=1.21.11 {
     public static final Identifier ID = Identifier.fromNamespaceAndPath("anarchymod", "join");
-    //? } elif >=1.21.7 {
-    /*public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath("anarchymod", "join");
-    *///?} else {
-    /*public static final ResourceLocation ID = ResourceLocation.tryBuild("anarchymod", "join");
-    *///?}
+    // ? } elif >=1.21.7 {
+    /*
+     * public static final ResourceLocation ID =
+     * ResourceLocation.fromNamespaceAndPath("anarchymod", "join");
+     */// ?} elif >=1.19.4 {
+    /*
+     * public static final ResourceLocation ID =
+     * ResourceLocation.tryBuild("anarchymod", "join");
+     */// ?} elif >=1.14.4 {
+    /*
+     * public static final ResourceLocation ID = new ResourceLocation("anarchymod",
+     * "join");
+     */// ?} else {
+    /*
+     * public static final Identifier ID = new Identifier("anarchymod", "join");
+     */// ?}
 
     private JoinPayload() {
     }
 
+    // ? if <=1.12.2 {
+    /*
+     * public static CustomPayloadC2SPacket createPacket() {
+     * return new CustomPayloadC2SPacket(ID.toString(), new
+     * PacketByteBuf(Unpooled.EMPTY_BUFFER));
+     * }
+     */// ?} elif <1.14.4 {
+    /*
+     * public static CustomPayloadC2SPacket createPacket() {
+     * return new CustomPayloadC2SPacket(ID, new
+     * PacketByteBuf(Unpooled.EMPTY_BUFFER));
+     * }
+     */// ?} elif <1.20.2 {
+    /*
+     * public static ServerboundCustomPayloadPacket createPacket() {
+     * return new ServerboundCustomPayloadPacket(ID, new
+     * FriendlyByteBuf(Unpooled.EMPTY_BUFFER));
+     * }
+     */// ?} else {
     public static ServerboundCustomPayloadPacket createPacket() {
-        //? if <1.20.2 {
-        /*return new ServerboundCustomPayloadPacket(ID, new FriendlyByteBuf(Unpooled.EMPTY_BUFFER));
-        *///?} else {
         return new ServerboundCustomPayloadPacket(new DiscardedPayload(ID));
-        //?}
     }
+    // ?}
 }

--- a/src/main/java/net/blockhost/anarchymod/mixin/BlockedServersMixin.java
+++ b/src/main/java/net/blockhost/anarchymod/mixin/BlockedServersMixin.java
@@ -11,13 +11,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class BlockedServersMixin {
 
     @Inject(method = "isBlockedServerHostName", at = @At("RETURN"), cancellable = true, remap = false)
-    // ? if <1.17 {
-    /*
-     * private static void isBlockedServerHostName(String server,
-     * CallbackInfoReturnable<Boolean> cir) {
-     */// ?} else {
+    //? if <1.17 {
+    /*private static void isBlockedServerHostName(String server, CallbackInfoReturnable<Boolean> cir) {
+    *///?} else {
     public void isBlockedServerHostName(String server, CallbackInfoReturnable<Boolean> cir) {
-        // ?}
+    //?}
         boolean contains = Domains.contains(server);
         if (contains) {
             cir.setReturnValue(false);

--- a/src/main/java/net/blockhost/anarchymod/mixin/BlockedServersMixin.java
+++ b/src/main/java/net/blockhost/anarchymod/mixin/BlockedServersMixin.java
@@ -11,7 +11,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class BlockedServersMixin {
 
     @Inject(method = "isBlockedServerHostName", at = @At("RETURN"), cancellable = true, remap = false)
+    // ? if <1.17 {
+    /*
+     * private static void isBlockedServerHostName(String server,
+     * CallbackInfoReturnable<Boolean> cir) {
+     */// ?} else {
     public void isBlockedServerHostName(String server, CallbackInfoReturnable<Boolean> cir) {
+        // ?}
         boolean contains = Domains.contains(server);
         if (contains) {
             cir.setReturnValue(false);

--- a/src/main/java/net/blockhost/anarchymod/mixin/ClientPacketListenerMixin.java
+++ b/src/main/java/net/blockhost/anarchymod/mixin/ClientPacketListenerMixin.java
@@ -2,10 +2,22 @@ package net.blockhost.anarchymod.mixin;
 
 import net.blockhost.anarchymod.Domains;
 import net.blockhost.anarchymod.JoinPayload;
+//? if <=1.13.2 {
+/*import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
+import net.minecraft.client.network.ServerInfo;
+*///?} elif <1.14.4 {
+/*import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.network.packet.GameJoinS2CPacket;
+import net.minecraft.client.options.ServerEntry;
+*///?} else {
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
+//?}
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -13,11 +25,54 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.logging.Logger;
 
+//? if <1.14.4 {
+/*@Mixin(ClientPlayNetworkHandler.class)
+*///?} else {
 @Mixin(ClientPacketListener.class)
+// ?}
 public class ClientPacketListenerMixin {
 
     private static final Logger LOGGER = Logger.getLogger("AnarchyMod-JoinNotifier");
 
+    // ? if <=1.13.2 {
+    /*
+     * @Inject(method = "onGameJoin", at = @At("RETURN"))
+     * private void afterLogin(GameJoinS2CPacket packet, CallbackInfo ci) {
+     * MinecraftClient client = MinecraftClient.getInstance();
+     * ServerInfo server = client.getCurrentServerEntry();
+     * if (server == null || !Domains.contains(server.address)) {
+     * return;
+     * }
+     *
+     * try {
+     * ClientPlayNetworkHandler listener = (ClientPlayNetworkHandler) (Object) this;
+     * listener.getClientConnection().send(JoinPayload.createPacket());
+     * } catch (RuntimeException error) {
+     * // Analytics must never be able to break an otherwise successful connection.
+     * LOGGER.warning("Failed to send join notification to " + server.address + ": "
+     * + error.getMessage());
+     * }
+     * }
+     */// ?} elif <1.14.4 {
+    /*
+     * @Inject(method = "onGameJoin", at = @At("RETURN"))
+     * private void afterLogin(GameJoinS2CPacket packet, CallbackInfo ci) {
+     * MinecraftClient client = MinecraftClient.getInstance();
+     * ServerEntry server = client.getCurrentServerEntry();
+     * if (server == null || !Domains.contains(server.address)) {
+     * return;
+     * }
+     *
+     * try {
+     * ClientPlayNetworkHandler listener = (ClientPlayNetworkHandler) (Object) this;
+     * listener.getClientConnection().send(JoinPayload.createPacket());
+     * } catch (RuntimeException error) {
+     * // Analytics must never be able to break an otherwise successful connection.
+     * LOGGER.warning("Failed to send join notification to " + server.address + ": "
+     * + error.getMessage());
+     * }
+     * }
+     */// ?} else {
     @Inject(method = "handleLogin", at = @At("RETURN"))
     private void afterLogin(ClientboundLoginPacket packet, CallbackInfo ci) {
         Minecraft client = Minecraft.getInstance();
@@ -34,4 +89,5 @@ public class ClientPacketListenerMixin {
             LOGGER.warning("Failed to send join notification to " + server.ip + ": " + error.getMessage());
         }
     }
+    // ?}
 }

--- a/src/main/java/net/blockhost/anarchymod/mixin/ClientPacketListenerMixin.java
+++ b/src/main/java/net/blockhost/anarchymod/mixin/ClientPacketListenerMixin.java
@@ -29,50 +29,46 @@ import java.util.logging.Logger;
 /*@Mixin(ClientPlayNetworkHandler.class)
 *///?} else {
 @Mixin(ClientPacketListener.class)
-// ?}
+//?}
 public class ClientPacketListenerMixin {
 
     private static final Logger LOGGER = Logger.getLogger("AnarchyMod-JoinNotifier");
 
-    // ? if <=1.13.2 {
-    /*
-     * @Inject(method = "onGameJoin", at = @At("RETURN"))
-     * private void afterLogin(GameJoinS2CPacket packet, CallbackInfo ci) {
-     * MinecraftClient client = MinecraftClient.getInstance();
-     * ServerInfo server = client.getCurrentServerEntry();
-     * if (server == null || !Domains.contains(server.address)) {
-     * return;
-     * }
-     *
-     * try {
-     * ClientPlayNetworkHandler listener = (ClientPlayNetworkHandler) (Object) this;
-     * listener.getClientConnection().send(JoinPayload.createPacket());
-     * } catch (RuntimeException error) {
-     * // Analytics must never be able to break an otherwise successful connection.
-     * LOGGER.warning("Failed to send join notification to " + server.address + ": "
-     * + error.getMessage());
-     * }
-     * }
-     */// ?} elif <1.14.4 {
-    /*
-     * @Inject(method = "onGameJoin", at = @At("RETURN"))
-     * private void afterLogin(GameJoinS2CPacket packet, CallbackInfo ci) {
-     * MinecraftClient client = MinecraftClient.getInstance();
-     * ServerEntry server = client.getCurrentServerEntry();
-     * if (server == null || !Domains.contains(server.address)) {
-     * return;
-     * }
-     *
-     * try {
-     * ClientPlayNetworkHandler listener = (ClientPlayNetworkHandler) (Object) this;
-     * listener.getClientConnection().send(JoinPayload.createPacket());
-     * } catch (RuntimeException error) {
-     * // Analytics must never be able to break an otherwise successful connection.
-     * LOGGER.warning("Failed to send join notification to " + server.address + ": "
-     * + error.getMessage());
-     * }
-     * }
-     */// ?} else {
+    //? if <=1.13.2 {
+    /*@Inject(method = "onGameJoin", at = @At("RETURN"))
+    private void afterLogin(GameJoinS2CPacket packet, CallbackInfo ci) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        ServerInfo server = client.getCurrentServerEntry();
+        if (server == null || !Domains.contains(server.address)) {
+            return;
+        }
+
+        try {
+            ClientPlayNetworkHandler listener = (ClientPlayNetworkHandler) (Object) this;
+            listener.getClientConnection().send(JoinPayload.createPacket());
+        } catch (RuntimeException error) {
+            // Analytics must never be able to break an otherwise successful connection.
+            LOGGER.warning("Failed to send join notification to " + server.address + ": " + error.getMessage());
+        }
+    }
+    *///?} elif <1.14.4 {
+    /*@Inject(method = "onGameJoin", at = @At("RETURN"))
+    private void afterLogin(GameJoinS2CPacket packet, CallbackInfo ci) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        ServerEntry server = client.getCurrentServerEntry();
+        if (server == null || !Domains.contains(server.address)) {
+            return;
+        }
+
+        try {
+            ClientPlayNetworkHandler listener = (ClientPlayNetworkHandler) (Object) this;
+            listener.getClientConnection().send(JoinPayload.createPacket());
+        } catch (RuntimeException error) {
+            // Analytics must never be able to break an otherwise successful connection.
+            LOGGER.warning("Failed to send join notification to " + server.address + ": " + error.getMessage());
+        }
+    }
+    *///?} else {
     @Inject(method = "handleLogin", at = @At("RETURN"))
     private void afterLogin(ClientboundLoginPacket packet, CallbackInfo ci) {
         Minecraft client = Minecraft.getInstance();
@@ -89,5 +85,5 @@ public class ClientPacketListenerMixin {
             LOGGER.warning("Failed to send join notification to " + server.ip + ": " + error.getMessage());
         }
     }
-    // ?}
+    //?}
 }

--- a/src/main/java/net/blockhost/anarchymod/mixin/ServerListMixin.java
+++ b/src/main/java/net/blockhost/anarchymod/mixin/ServerListMixin.java
@@ -27,57 +27,46 @@ public class ServerListMixin {
     @Unique
     private static final String DEFAULT_SERVER_ADDRESS = "6b6t.org";
 
-    // ? if <=1.13.2 {
-    /*
-     * @Shadow
-     *
-     * @Final
-     * private List<ServerInfo> servers;
-     */// ?} elif <1.14.4 {
-    /*
-     * @Shadow
-     *
-     * @Final
-     * private List<ServerEntry> serverEntries;
-     */// ?} else {
+    //? if <=1.13.2 {
+    /*@Shadow
+    @Final
+    private List<ServerInfo> servers;
+    *///?} elif <1.14.4 {
+    /*@Shadow
+    @Final
+    private List<ServerEntry> serverEntries;
+    *///?} else {
     @Shadow
     @Final
     private List<ServerData> serverList;
-    // ?}
+    //?}
 
-    // ? if <=1.13.2 {
-    /*
-     * @Inject(method = "loadFile", at = @At("RETURN"))
-     * public void afterLoad(CallbackInfo ci) {
-     * if (servers.stream().noneMatch(data -> Domains.matches(data.address, "*." +
-     * DEFAULT_SERVER_ADDRESS))) {
-     * servers.add(0, new ServerInfo("6b6t", DEFAULT_SERVER_ADDRESS, false));
-     * }
-     * }
-     */// ?} elif <1.14.4 {
-    /*
-     * @Inject(method = "loadFile", at = @At("RETURN"))
-     * public void afterLoad(CallbackInfo ci) {
-     * if (serverEntries.stream().noneMatch(data -> Domains.matches(data.address,
-     * "*." + DEFAULT_SERVER_ADDRESS))) {
-     * serverEntries.add(0, new ServerEntry("6b6t", DEFAULT_SERVER_ADDRESS, false));
-     * }
-     * }
-     */// ?} else {
+    //? if <=1.13.2 {
+    /*@Inject(method = "loadFile", at = @At("RETURN"))
+    public void afterLoad(CallbackInfo ci) {
+        if (servers.stream().noneMatch(data -> Domains.matches(data.address, "*." + DEFAULT_SERVER_ADDRESS))) {
+            servers.add(0, new ServerInfo("6b6t", DEFAULT_SERVER_ADDRESS, false));
+        }
+    }
+    *///?} elif <1.14.4 {
+    /*@Inject(method = "loadFile", at = @At("RETURN"))
+    public void afterLoad(CallbackInfo ci) {
+        if (serverEntries.stream().noneMatch(data -> Domains.matches(data.address, "*." + DEFAULT_SERVER_ADDRESS))) {
+            serverEntries.add(0, new ServerEntry("6b6t", DEFAULT_SERVER_ADDRESS, false));
+        }
+    }
+    *///?} else {
     @Inject(method = "load", at = @At("RETURN"))
     public void afterLoad(CallbackInfo ci) {
         if (serverList.stream().noneMatch(data -> Domains.matches(data.ip, "*." + DEFAULT_SERVER_ADDRESS))) {
-            // ? if <1.20.2 {
-            /*
-             * serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, false));
-             */// ? } elif <1.20.5 {
-            /*
-             * serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS,
-             * ServerData.Type.OTHER));
-             */// ?} else {
+            //? if <1.20.2 {
+            /*serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, false));
+            *///? } elif <1.20.5 {
+            /*serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, ServerData.Type.OTHER));
+            *///?} else {
             serverList.addFirst(new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, ServerData.Type.OTHER));
-            // ?}
+            //?}
         }
     }
-    // ?}
+    //?}
 }

--- a/src/main/java/net/blockhost/anarchymod/mixin/ServerListMixin.java
+++ b/src/main/java/net/blockhost/anarchymod/mixin/ServerListMixin.java
@@ -1,8 +1,16 @@
 package net.blockhost.anarchymod.mixin;
 
 import net.blockhost.anarchymod.Domains;
+//? if <=1.13.2 {
+/*import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.option.ServerList;
+*///?} elif <1.14.4 {
+/*import net.minecraft.client.options.ServerEntry;
+import net.minecraft.client.options.ServerList;
+*///?} else {
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.ServerList;
+//?}
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -19,20 +27,57 @@ public class ServerListMixin {
     @Unique
     private static final String DEFAULT_SERVER_ADDRESS = "6b6t.org";
 
+    // ? if <=1.13.2 {
+    /*
+     * @Shadow
+     *
+     * @Final
+     * private List<ServerInfo> servers;
+     */// ?} elif <1.14.4 {
+    /*
+     * @Shadow
+     *
+     * @Final
+     * private List<ServerEntry> serverEntries;
+     */// ?} else {
     @Shadow
     @Final
     private List<ServerData> serverList;
+    // ?}
 
+    // ? if <=1.13.2 {
+    /*
+     * @Inject(method = "loadFile", at = @At("RETURN"))
+     * public void afterLoad(CallbackInfo ci) {
+     * if (servers.stream().noneMatch(data -> Domains.matches(data.address, "*." +
+     * DEFAULT_SERVER_ADDRESS))) {
+     * servers.add(0, new ServerInfo("6b6t", DEFAULT_SERVER_ADDRESS, false));
+     * }
+     * }
+     */// ?} elif <1.14.4 {
+    /*
+     * @Inject(method = "loadFile", at = @At("RETURN"))
+     * public void afterLoad(CallbackInfo ci) {
+     * if (serverEntries.stream().noneMatch(data -> Domains.matches(data.address,
+     * "*." + DEFAULT_SERVER_ADDRESS))) {
+     * serverEntries.add(0, new ServerEntry("6b6t", DEFAULT_SERVER_ADDRESS, false));
+     * }
+     * }
+     */// ?} else {
     @Inject(method = "load", at = @At("RETURN"))
     public void afterLoad(CallbackInfo ci) {
         if (serverList.stream().noneMatch(data -> Domains.matches(data.ip, "*." + DEFAULT_SERVER_ADDRESS))) {
-            //? if <1.20.2 {
-            /*serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, false));
-            *///? } elif <1.20.5 {
-            /*serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, ServerData.Type.OTHER));
-            *///?} else {
+            // ? if <1.20.2 {
+            /*
+             * serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, false));
+             */// ? } elif <1.20.5 {
+            /*
+             * serverList.add(0, new ServerData("6b6t", DEFAULT_SERVER_ADDRESS,
+             * ServerData.Type.OTHER));
+             */// ?} else {
             serverList.addFirst(new ServerData("6b6t", DEFAULT_SERVER_ADDRESS, ServerData.Type.OTHER));
-            //?}
+            // ?}
         }
     }
+    // ?}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "anarchymod",
   "version": "${version}",
   "name": "AnarchyMod",
-  "description": "The Minecraft mod required to play on 6b6t — bypass Mojang's ban of the world's biggest anarchy server.",
+  "description": "The Minecraft mod required to play on 6b6t - bypass Mojang's ban of the world's biggest anarchy server.",
   "authors": [
     "6b6t"
   ],

--- a/src/test/java/net/blockhost/anarchymod/JoinPayloadTest.java
+++ b/src/test/java/net/blockhost/anarchymod/JoinPayloadTest.java
@@ -1,8 +1,16 @@
 package net.blockhost.anarchymod;
 
 import io.netty.buffer.Unpooled;
+//? if <1.14.4 {
+/*import net.minecraft.util.PacketByteBuf;
+*///?} else {
 import net.minecraft.network.FriendlyByteBuf;
-//? if <1.20.2 {
+//?}
+//? if <=1.13.2 {
+/*import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+*///?} elif <1.14.4 {
+/*import net.minecraft.server.network.packet.CustomPayloadC2SPacket;
+*///?} elif <1.20.2 {
 /*import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
 *///?} else {
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
@@ -15,22 +23,40 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class JoinPayloadTest {
 
     @Test
-    void encodesAnEmptyJoinPayload() {
+    void encodesAnEmptyJoinPayload() throws Exception {
+        // ? if <1.14.4 {
+        /*
+         * PacketByteBuf buffer = new PacketByteBuf(Unpooled.buffer());
+         */// ?} else {
         FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.buffer());
+        // ?}
 
         try {
+            // ? if <1.14.4 {
+            /*
+             * CustomPayloadC2SPacket packet = JoinPayload.createPacket();
+             */// ?} else {
             ServerboundCustomPayloadPacket packet = JoinPayload.createPacket();
-            //? if <1.20.5 {
-            /*packet.write(buffer);
-            *///?} else {
+            // ?}
+            // ? if <1.20.5 {
+            /*
+             * packet.write(buffer);
+             */// ?} else {
             ServerboundCustomPayloadPacket.STREAM_CODEC.encode(buffer, packet);
-            //?}
+            // ?}
 
-            //? if >=1.21.11 {
+            // ? if >=1.21.11 {
             assertEquals(JoinPayload.ID, buffer.readIdentifier());
-            //?} else {
-            /*assertEquals(JoinPayload.ID, buffer.readResourceLocation());
-            *///?}
+            // ?} elif >=1.14.4 {
+            /*
+             * assertEquals(JoinPayload.ID, buffer.readResourceLocation());
+             */// ?} elif >1.12.2 {
+            /*
+             * assertEquals(JoinPayload.ID, buffer.readIdentifier());
+             */// ?} else {
+            /*
+             * assertEquals(JoinPayload.ID.toString(), buffer.readString(32767));
+             */// ?}
             assertFalse(buffer.isReadable());
         } finally {
             buffer.release();

--- a/src/test/java/net/blockhost/anarchymod/JoinPayloadTest.java
+++ b/src/test/java/net/blockhost/anarchymod/JoinPayloadTest.java
@@ -24,39 +24,33 @@ class JoinPayloadTest {
 
     @Test
     void encodesAnEmptyJoinPayload() throws Exception {
-        // ? if <1.14.4 {
-        /*
-         * PacketByteBuf buffer = new PacketByteBuf(Unpooled.buffer());
-         */// ?} else {
+        //? if <1.14.4 {
+        /*PacketByteBuf buffer = new PacketByteBuf(Unpooled.buffer());
+        *///?} else {
         FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.buffer());
-        // ?}
+        //?}
 
         try {
-            // ? if <1.14.4 {
-            /*
-             * CustomPayloadC2SPacket packet = JoinPayload.createPacket();
-             */// ?} else {
+            //? if <1.14.4 {
+            /*CustomPayloadC2SPacket packet = JoinPayload.createPacket();
+            *///?} else {
             ServerboundCustomPayloadPacket packet = JoinPayload.createPacket();
-            // ?}
-            // ? if <1.20.5 {
-            /*
-             * packet.write(buffer);
-             */// ?} else {
+            //?}
+            //? if <1.20.5 {
+            /*packet.write(buffer);
+            *///?} else {
             ServerboundCustomPayloadPacket.STREAM_CODEC.encode(buffer, packet);
-            // ?}
+            //?}
 
-            // ? if >=1.21.11 {
+            //? if >=1.21.11 {
             assertEquals(JoinPayload.ID, buffer.readIdentifier());
-            // ?} elif >=1.14.4 {
-            /*
-             * assertEquals(JoinPayload.ID, buffer.readResourceLocation());
-             */// ?} elif >1.12.2 {
-            /*
-             * assertEquals(JoinPayload.ID, buffer.readIdentifier());
-             */// ?} else {
-            /*
-             * assertEquals(JoinPayload.ID.toString(), buffer.readString(32767));
-             */// ?}
+            //?} elif >=1.14.4 {
+            /*assertEquals(JoinPayload.ID, buffer.readResourceLocation());
+            *///?} elif >1.12.2 {
+            /*assertEquals(JoinPayload.ID, buffer.readIdentifier());
+            *///?} else {
+            /*assertEquals(JoinPayload.ID.toString(), buffer.readString(32767));
+            *///?}
             assertFalse(buffer.isReadable());
         } finally {
             buffer.release();

--- a/versions/1.10.2/gradle.properties
+++ b/versions/1.10.2/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.10.2
+loader_version=0.19.3
+yarn_group=net.legacyfabric
+yarn_mappings=1.10.2+build.604
+java_version=8

--- a/versions/1.11.2/gradle.properties
+++ b/versions/1.11.2/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.11.2
+loader_version=0.19.3
+yarn_group=net.legacyfabric
+yarn_mappings=1.11.2+build.604
+java_version=8

--- a/versions/1.12.2/gradle.properties
+++ b/versions/1.12.2/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.12.2
+loader_version=0.19.3
+yarn_group=net.legacyfabric
+yarn_mappings=1.12.2+build.604
+java_version=8

--- a/versions/1.13.2/gradle.properties
+++ b/versions/1.13.2/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.13.2
+loader_version=0.19.3
+yarn_group=net.legacyfabric
+yarn_mappings=1.13.2+build.604
+java_version=8

--- a/versions/1.14.3/gradle.properties
+++ b/versions/1.14.3/gradle.properties
@@ -1,0 +1,4 @@
+minecraft_version=1.14.3
+loader_version=0.19.3
+yarn_mappings=1.14.3+build.13
+java_version=8

--- a/versions/1.14.4/gradle.properties
+++ b/versions/1.14.4/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.14.4
+loader_version=0.19.3
+java_version=8

--- a/versions/1.15.1/gradle.properties
+++ b/versions/1.15.1/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.15.1
+loader_version=0.19.3
+java_version=8

--- a/versions/1.15.2/gradle.properties
+++ b/versions/1.15.2/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.15.2
+loader_version=0.19.3
+java_version=8

--- a/versions/1.15/gradle.properties
+++ b/versions/1.15/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.15
+loader_version=0.19.3
+java_version=8

--- a/versions/1.16.1/gradle.properties
+++ b/versions/1.16.1/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.16.1
+loader_version=0.19.3
+java_version=8

--- a/versions/1.16.2/gradle.properties
+++ b/versions/1.16.2/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.16.2
+loader_version=0.19.3
+java_version=8

--- a/versions/1.16.3/gradle.properties
+++ b/versions/1.16.3/gradle.properties
@@ -1,3 +1,3 @@
-minecraft_version=1.16.4
+minecraft_version=1.16.3
 loader_version=0.19.3
 java_version=8

--- a/versions/1.16.3/gradle.properties
+++ b/versions/1.16.3/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.16.4
+loader_version=0.19.3
+java_version=8

--- a/versions/1.16.4/gradle.properties
+++ b/versions/1.16.4/gradle.properties
@@ -1,5 +1,3 @@
-minecraft_version=1.11.2
+minecraft_version=1.16.4
 loader_version=0.19.3
-yarn_group=net.legacyfabric
-yarn_mappings=1.11.2+build.604
 java_version=8

--- a/versions/1.16.4/gradle.properties
+++ b/versions/1.16.4/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.11.2
+loader_version=0.19.3
+yarn_group=net.legacyfabric
+yarn_mappings=1.11.2+build.604
+java_version=8

--- a/versions/1.16.5/gradle.properties
+++ b/versions/1.16.5/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.16.4
+loader_version=0.19.3
+java_version=8

--- a/versions/1.16.5/gradle.properties
+++ b/versions/1.16.5/gradle.properties
@@ -1,3 +1,3 @@
-minecraft_version=1.16.4
+minecraft_version=1.16.5
 loader_version=0.19.3
 java_version=8

--- a/versions/1.16/gradle.properties
+++ b/versions/1.16/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.16
+loader_version=0.19.3
+java_version=8

--- a/versions/1.17.1/gradle.properties
+++ b/versions/1.17.1/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.17.1
+loader_version=0.19.3
+java_version=17

--- a/versions/1.17/gradle.properties
+++ b/versions/1.17/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.17
+loader_version=0.19.3
+java_version=17

--- a/versions/1.18.1/gradle.properties
+++ b/versions/1.18.1/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.18.1
+loader_version=0.19.3
+java_version=17

--- a/versions/1.18.2/gradle.properties
+++ b/versions/1.18.2/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.18.2
+loader_version=0.19.3
+java_version=17

--- a/versions/1.18/gradle.properties
+++ b/versions/1.18/gradle.properties
@@ -1,3 +1,3 @@
-minecraft_version=1.17.1
+minecraft_version=1.18
 loader_version=0.19.3
 java_version=17

--- a/versions/1.18/gradle.properties
+++ b/versions/1.18/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.17.1
+loader_version=0.19.3
+java_version=17

--- a/versions/1.19.1/gradle.properties
+++ b/versions/1.19.1/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.19.1
+loader_version=0.19.3
+java_version=17

--- a/versions/1.19.2/gradle.properties
+++ b/versions/1.19.2/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.19.2
+loader_version=0.19.3
+java_version=17

--- a/versions/1.19.3/gradle.properties
+++ b/versions/1.19.3/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.19.3
+loader_version=0.19.3
+java_version=17

--- a/versions/1.19.4/gradle.properties
+++ b/versions/1.19.4/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.19.4
-loader_version=0.14.14
+loader_version=0.19.3
 java_version=17

--- a/versions/1.19/gradle.properties
+++ b/versions/1.19/gradle.properties
@@ -1,0 +1,3 @@
+minecraft_version=1.19
+loader_version=0.19.3
+java_version=17

--- a/versions/1.20.1/gradle.properties
+++ b/versions/1.20.1/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.20.1
-loader_version=0.16.10
+loader_version=0.19.3
 java_version=17

--- a/versions/1.20.2/gradle.properties
+++ b/versions/1.20.2/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.20.2
-loader_version=0.14.22
+loader_version=0.19.3
 java_version=17

--- a/versions/1.20.3/gradle.properties
+++ b/versions/1.20.3/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.20.3
-loader_version=0.14.23
+loader_version=0.19.3
 java_version=17

--- a/versions/1.20.4/gradle.properties
+++ b/versions/1.20.4/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.20.4
-loader_version=0.15.1
+loader_version=0.19.3
 java_version=17

--- a/versions/1.20.5/gradle.properties
+++ b/versions/1.20.5/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.20.5
-loader_version=0.15.6
+loader_version=0.19.3
 java_version=21

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.20.6
-loader_version=0.15.6
+loader_version=0.19.3
 java_version=21

--- a/versions/1.20/gradle.properties
+++ b/versions/1.20/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.20
-loader_version=0.14.21
+loader_version=0.19.3
 java_version=17

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.1
-loader_version=0.15.11
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.10
-loader_version=0.17.0
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.11
-loader_version=0.17.3
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.2/gradle.properties
+++ b/versions/1.21.2/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.2
-loader_version=0.16.7
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.3/gradle.properties
+++ b/versions/1.21.3/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.3
-loader_version=0.16.8
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.4
-loader_version=0.16.9
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.5
-loader_version=0.16.10
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.6
-loader_version=0.16.13
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.7/gradle.properties
+++ b/versions/1.21.7/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.7
-loader_version=0.16.13
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.8
-loader_version=0.16.13
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21.9/gradle.properties
+++ b/versions/1.21.9/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21.9
-loader_version=0.17.0
+loader_version=0.19.3
 java_version=21

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.21
-loader_version=0.15.11
+loader_version=0.19.3
 java_version=21

--- a/versions/1.9.4/gradle.properties
+++ b/versions/1.9.4/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version=1.9.4
+loader_version=0.19.3
+yarn_group=net.legacyfabric
+yarn_mappings=1.9.4+build.604
+java_version=8

--- a/versions/26.1.1/gradle.properties
+++ b/versions/26.1.1/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=26.1.1
-loader_version=0.18.4
+loader_version=0.19.3
 java_version=25

--- a/versions/26.1.2/gradle.properties
+++ b/versions/26.1.2/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=26.1.2
-loader_version=0.18.4
+loader_version=0.19.3
 java_version=25

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=26.1
-loader_version=0.18.4
+loader_version=0.19.3
 java_version=25

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=26.2
-loader_version=0.18.4
+loader_version=0.19.3
 java_version=25

--- a/yarn-build.gradle.kts
+++ b/yarn-build.gradle.kts
@@ -1,0 +1,95 @@
+plugins {
+    id("net.fabricmc.fabric-loom-remap") version "1.17.17"
+    id("maven-publish")
+}
+
+val minecraftVersion = stonecutter.current.project
+val loaderVersion = property("loader_version") as String
+val yarnMappings = property("yarn_mappings") as String
+val yarnGroup = if (hasProperty("yarn_group")) property("yarn_group") as String else "net.fabricmc"
+val javaVersion = (property("java_version") as String).toInt()
+
+repositories {
+    maven("https://maven.legacyfabric.net/")
+}
+
+version = property("mod_version")!!
+group = property("maven_group")!!
+
+base {
+    archivesName.set("anarchymod-mc-${minecraftVersion}")
+}
+
+// for fallback since 6 requires 17+ and 5 requires <17
+val junitJupiterVersion = if (javaVersion >= 17) "6.1.2" else "5.10.3"
+
+dependencies {
+    minecraft("com.mojang:minecraft:$minecraftVersion")
+    mappings("$yarnGroup:yarn:$yarnMappings:v2")
+    modImplementation("net.fabricmc:fabric-loader:$loaderVersion")
+    implementation("com.google.code.gson:gson:2.14.0")
+    testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+loom {
+    runConfigs.all {
+        ideConfigGenerated(true)
+        runDir = "../../run"
+    }
+}
+
+tasks.processResources {
+    inputs.property("version", project.version)
+    inputs.property("minecraft_version", minecraftVersion)
+    inputs.property("loader_version", loaderVersion)
+    inputs.property("java_version", javaVersion)
+    filteringCharset = "UTF-8"
+
+    filesMatching("fabric.mod.json") {
+        expand(
+            "version" to project.version,
+            "minecraft_version" to minecraftVersion,
+            "loader_version" to loaderVersion,
+            "java_version" to javaVersion
+        )
+    }
+
+    filesMatching("anarchymod.mixins.json") {
+        expand(
+            "java_version" to javaVersion
+        )
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    // javac only gained --release in JDK 9; JDK 8 toolchains already target their own version.
+    if (javaVersion >= 9) {
+        options.release.set(javaVersion)
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    withSourcesJar()
+}
+
+tasks.jar {
+    from("LICENSE") {
+        rename { "${it}_${base.archivesName.get()}" }
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            artifactId = base.archivesName.get()
+            from(components["java"])
+        }
+    }
+}

--- a/yarn-build.gradle.kts
+++ b/yarn-build.gradle.kts
@@ -20,15 +20,12 @@ base {
     archivesName.set("anarchymod-mc-${minecraftVersion}")
 }
 
-// for fallback since 6 requires 17+ and 5 requires <17
-val junitJupiterVersion = if (javaVersion >= 17) "6.1.2" else "5.10.3"
-
 dependencies {
     minecraft("com.mojang:minecraft:$minecraftVersion")
     mappings("$yarnGroup:yarn:$yarnMappings:v2")
     modImplementation("net.fabricmc:fabric-loader:$loaderVersion")
     implementation("com.google.code.gson:gson:2.14.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
@@ -64,10 +61,6 @@ tasks.processResources {
 
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
-    // javac only gained --release in JDK 9; JDK 8 toolchains already target their own version.
-    if (javaVersion >= 9) {
-        options.release.set(javaVersion)
-    }
 }
 
 tasks.test {


### PR DESCRIPTION
changes are as follows:
- reset loader version back to 0.19.3 because of reported security issues in older versions
- added java 8 support so we can have older version than 1.17
- replaced all emdashes with normal dashes
- I git ignored a /logs dir that randomly appeared idk if its supposed to be there but I ignored it
- I redid the tables so for example 1.20 has 1.20.* in its list instead of separate entries
- Cleaned up build workflow so it just uploads them all at once instead of individually
- Releases versioning is dynamic based off of minecraft_version in gradle.properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for Minecraft versions 1.9.4 through 1.21.11 and 26.1–26.2.
- Release downloads and supported-version tables are now generated automatically.
- Added required Java version details for each supported Minecraft version.

## Bug Fixes
- Improved compatibility across legacy and modern Minecraft networking APIs.
- Updated supported versions to use current loader releases.
- Improved Java 8 compatibility for older versions.

## Documentation
- Added direct download links and clearer supported-version listings.
- Standardized project descriptions and release information formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->